### PR TITLE
通知で(添付あり)を追加。LINE連携不可メッセージ表示。

### DIFF
--- a/app/Http/Controllers/Api/PostCommentController.php
+++ b/app/Http/Controllers/Api/PostCommentController.php
@@ -44,7 +44,8 @@ class PostCommentController extends Controller
       "created_id" => Auth::id(),
       "updated_id" => Auth::id()
     ]);
-Log::info("public_path=" . public_path() . ', storage_path=' . storage_path());
+    Log::info("public_path=" . public_path() . ', storage_path=' . storage_path());
+    $hasAttachment = false;
     if ($request->allFiles()) { //添付がある場合
 //      $allowedfileExtension=['pdf','jpg','jpeg','png','gif','xlsx','docx'];
       $files = $request->file('comment_files');
@@ -73,6 +74,7 @@ Log::info("public_path=" . public_path() . ', storage_path=' . storage_path());
           "updated_id" => Auth::id()
         ]);
       }
+      $hasAttachment = true;
     }
 
     // コメント数の更新
@@ -85,7 +87,7 @@ Log::info("public_path=" . public_path() . ', storage_path=' . storage_path());
       Log::info('コメント通知実行');
       $startTime = microtime(true);
       $fromUser = User::findOrFail(Auth::id());
-      $this->dispatch(new PostNotificationJob($fromUser, $post, $postCommentResult));
+      $this->dispatch(new PostNotificationJob($fromUser, $post, $postCommentResult, $hasAttachment));
       $runningTime =  microtime(true) - $startTime;
       Log::info('メール/LINE送信キュー入れ処理時間: ' . $runningTime . ' [s]');
     }

--- a/app/Jobs/PostNotificationJob.php
+++ b/app/Jobs/PostNotificationJob.php
@@ -135,6 +135,9 @@ class PostNotificationJob implements ShouldQueue
     } else {
       $message = $this->fromMember->name . "さんが投稿しました。\n「" . $title . "」\n" . $this->post->content;
     }
+    if ($this->hasAttachment) {
+      $message .= PHP_EOL . '(添付あり)';
+    }
     Log::info('タイトル：' . $title);
 
     // 一人ずつ間隔を空けながら送信

--- a/app/Jobs/PostNotificationJob.php
+++ b/app/Jobs/PostNotificationJob.php
@@ -28,18 +28,22 @@ class PostNotificationJob implements ShouldQueue
   public $fromMember;
   public $post;
   public $postComment;
+  public $hasAttachment;
 
   /**
-   * コンストラクタ。投稿と投稿コメントで共用。$postには必ず値が入り、$postCommentには投稿コメント通知の場合のみ値が入る。
+   * コンストラクタ。投稿と投稿コメントで共用。$postには必ず値が入り、
+   * $postCommentには投稿コメント通知の場合のみ値が入る。
    * @param $fromMember
    * @param $post
    * @param $postComment
+   * @param $hasAttachment
    */
-  public function __construct($fromMember, $post, $postComment)
+  public function __construct($fromMember, $post, $postComment, $hasAttachment)
   {
     $this->fromMember = $fromMember;
     $this->post = $post;
     $this->postComment = $postComment;
+    $this->hasAttachment = $hasAttachment;
   }
 
   /**
@@ -77,6 +81,9 @@ class PostNotificationJob implements ShouldQueue
       $content = $this->fromMember->name . "さんがコメントしました。\n\n" . $this->postComment->comment_text;
     } else {
       $content = $this->fromMember->name . "さんが投稿しました。\n\n" . $this->post->content;
+    }
+    if ($this->hasAttachment) {
+      $content .= PHP_EOL . '(添付あり)';
     }
     Log::info('タイトル：' . $title);
 

--- a/resources/assets/js/components/Settings.vue
+++ b/resources/assets/js/components/Settings.vue
@@ -43,7 +43,7 @@
           </v-ons-list-item>
           <v-ons-list-item >
             <img src="/img/LINE_APP.png" style="width:22px" class="mr-5"> LINEで通知を受け取る
-            <div v-if="true" style="text-align:left">
+            <div v-if="isIOSAndPWA" style="text-align:left">
               <span class="small gray left">
               ホーム画面のアイコンから起動している場合は設定できません。<br>Safariから開いて設定してください。
               </span>

--- a/resources/assets/js/components/Settings.vue
+++ b/resources/assets/js/components/Settings.vue
@@ -43,6 +43,9 @@
           </v-ons-list-item>
           <v-ons-list-item >
             <img src="/img/LINE_APP.png" style="width:22px" class="mr-5"> LINEで通知を受け取る
+            <div v-if="isIOSAndPWA">
+              ホーム画面のアイコンから起動している場合は設定できません。Safariから開いて設定してください。
+            </div>
             <div class="right">
               <v-ons-switch v-model="lineNotificationFlg"
                             @click="updateLINENotificationFlg()"></v-ons-switch>
@@ -118,6 +121,7 @@
         loading: false,
         errored: false,
         posting: false,
+        isIOSAndPWA: this.$ons.platform.isIOS() && location.href.indexOf('launcher=true') != -1
       }
     },
     computed: {

--- a/resources/assets/js/components/Settings.vue
+++ b/resources/assets/js/components/Settings.vue
@@ -43,8 +43,10 @@
           </v-ons-list-item>
           <v-ons-list-item >
             <img src="/img/LINE_APP.png" style="width:22px" class="mr-5"> LINEで通知を受け取る
-            <div v-if="isIOSAndPWA">
-              ホーム画面のアイコンから起動している場合は設定できません。Safariから開いて設定してください。
+            <div v-if="true" style="text-align:left">
+              <span class="small gray left">
+              ホーム画面のアイコンから起動している場合は設定できません。<br>Safariから開いて設定してください。
+              </span>
             </div>
             <div class="right">
               <v-ons-switch v-model="lineNotificationFlg"


### PR DESCRIPTION
投稿時の通知、投稿へのコメント時の通知の本文で、添付ファイルがある場合は(添付あり)との記載を追加 #50
PWA on iOSの場合にLINE連携ができない旨のメッセージを表示 #64